### PR TITLE
Automated Container Builds & bump to sdk:6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}        
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ env.OWNER_LC }}
+          password: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/pgstosrt:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/pgstosrt:${{ github.ref_name }}
+            ghcr.io/${{ env.OWNER_LC }}/pgstosrt:latest
+            ghcr.io/${{ env.OWNER_LC }}/pgstosrt:${{ github.ref_name }}            

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=builder /src/PgsToSrt/out .
 COPY --from=builder /tessdata /tessdata
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
+RUN apt-get update && \
+    apt-get install libtesseract4 \
+    && chmod +x /entrypoint.sh
 # Docker for Windows: EOL must be LF.
 ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ RUN apt-get update && \
 COPY . /src
 RUN cd /src && \
     dotnet restore  && \
-    dotnet publish -c Release -o /src/PgsToSrt/out && \
-    mv /src/entrypoint.sh /entrypoint.sh && chmod +x /entrypoint.sh && \
-    mv /src/PgsToSrt/out /app
-
+    dotnet publish -c Release -o /src/PgsToSrt/out
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0
 WORKDIR /app
@@ -22,5 +19,6 @@ VOLUME /tessdata
 COPY --from=builder /src/PgsToSrt/out .
 COPY entrypoint.sh /entrypoint.sh
 
+RUN chmod +x /entrypoint.sh
 # Docker for Windows: EOL must be LF.
 ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.101-focal-amd64 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
 
 RUN apt-get update && \
     apt-get install -y automake ca-certificates g++ git libtool libtesseract4 make pkg-config libc6-dev && \
@@ -11,10 +11,16 @@ RUN cd /src && \
     mv /src/entrypoint.sh /entrypoint.sh && chmod +x /entrypoint.sh && \
     mv /src/PgsToSrt/out /app
 
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+WORKDIR /app
 ENV LANGUAGE=eng
 ENV INPUT=/input.sup
 ENV OUTPUT=/output.srt
 VOLUME /tessdata
+
+COPY --from=builder /src/PgsToSrt/out .
+COPY entrypoint.sh /entrypoint.sh
 
 # Docker for Windows: EOL must be LF.
 ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /tessdata /tessdata
 COPY entrypoint.sh /entrypoint.sh
 
 RUN apt-get update && \
-    apt-get install libtesseract4 \
+    apt-get install -y libtesseract4 \
     && chmod +x /entrypoint.sh
 # Docker for Windows: EOL must be LF.
 ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV OUTPUT=/output.srt
 VOLUME /tessdata
 
 COPY --from=builder /src/PgsToSrt/out .
+COPY --from=builder /tessdata /tessdata
 COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh

--- a/PgsToSrt/PgsToSrt.csproj
+++ b/PgsToSrt/PgsToSrt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyVersion>1.4.2.0</AssemblyVersion>
     <FileVersion>1.4.2.0</FileVersion>
     <Version>1.4.2</Version>


### PR DESCRIPTION
I noticed the images on Docker Hub were a bit behind on the commits made in this repo, which led me to creating a GitHub Action that automates this process. However when building, I encountered some issues due to `<TargetFrameworks>` being set to `net5.0;net6.0` which I now replaced with `net6.0`. I did the same for the Dockerfile, used 6.0 instead of 5 and made it multi-stage.

For this to work it needs a few secrets to be configured [here](https://github.com/Tentacule/PgsToSrt/settings/secrets/actions) in order to succeed:
* `PERSONAL_ACCESS_TOKEN` 
* `DOCKERHUB_USERNAME`
* `DOCKERHUB_TOKEN`

The value for `PERSONAL_ACCESS_TOKEN` can be acquired from your profile with the following permissions: https://github.com/settings/tokens --> Personal access tokens --> Generate new token:
* Repo
* write:packages
    * read:packages

Thanks in advance!