### PR TITLE
Dockerfile dotnet6 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.101-focal-amd64 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal-amd64 AS builder
 
 RUN apt-get update && \
     apt-get install -y automake ca-certificates g++ git libtool libtesseract4 make pkg-config libc6-dev && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 COPY . /src
 RUN cd /src && \
     dotnet restore  && \
-    dotnet publish -c Release -o /src/PgsToSrt/out && \
+    dotnet publish -c Release -f net6.0 -o /src/PgsToSrt/out && \
     mv /src/entrypoint.sh /entrypoint.sh && chmod +x /entrypoint.sh && \
     mv /src/PgsToSrt/out /app
 


### PR DESCRIPTION
This PR addresses a small issue (#29) that was introduced when .NET 6.0 support was added to the project. Because both 5.0 and 6.0 were added as potential targets, the dotnet restore and publish commands would try to target both, but the base image of the Dockerfile is the .NET 5.0 SDK and can't build .NET 6.0 targets.