### PR TITLE
Added all arguments to container entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ dotnet PgsToSrt.dll --input video1.fr.sup --output video1.fr.srt --tesseractlang
 dotnet PgsToSrt.dll --input video1.mkv --output video1.srt --track 4
 ```
 #### Example (Docker)
+View entrypoint.sh for full list of available arguments
 ```
 docker run -it --rm -v /data:/data \
            -e INPUT=/data/myImageSubtitle.sup \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,29 @@
-#!/bin/sh
-dotnet /app/PgsToSrt.dll --tesseractdata /tessdata --tesseractlanguage "$LANGUAGE" --input "$INPUT" --output "$OUTPUT"
+#!/bin/bash
+
+args=()
+
+if [[ ! -z "${INPUT}" ]]; then
+  args+=" --input ${INPUT}"
+fi
+if [[ ! -z "${OUTPUT}" ]]; then
+  args+=" --output ${OUTPUT}"
+fi
+if [[ ! -z "${TRACK}" ]]; then
+  args+=" --track ${TRACK}"
+fi
+if [[ ! -z "${TRACK_LANGUAGE}" ]]; then
+  args+=" --trackLanguage ${TRACK_LANGUAGE}"
+fi
+if [[ ! -z "${LANGUAGE}" ]]; then
+  args+=" --tesseractlanguage ${LANGUAGE}"
+fi
+if [[ ! -z "${TESSDATA}" ]]; then
+  args+=" --tesseractdata ${TESSDATA}"
+else
+  args+=" --tesseractdata /tessdata"
+fi
+
+ARGS=${args// / }
+
+echo "dotnet /app/PgsToSrt.dll $ARGS"
+dotnet /app/PgsToSrt.dll $ARGS


### PR DESCRIPTION
This PR fleshes out the entrypoint.sh file for Docker container runs to support all of the command line arguments that the app supports outside of the container. Each argument is checked to see if the environment variable for it was defined in the docker run command, if it was defined then it is added to the argument list which is expanded at the final app execution command.

One exception is `TESSDATA` (`--tesseractdata=`), by default this is mounted in the container as /tessdata but if no argument is provided, the app in the container believes it is located at /app/tessdata and can't find it. So if no other tessdata location is specified, it will explicitly use the default that is mounted in the container.

Also the readme was updated to reflect these environment variables.