### PR TITLE
Use SingleBlock segmentation mode for tesseract OCR

### DIFF
--- a/src/PgsToSrt/PgsOcr.cs
+++ b/src/PgsToSrt/PgsOcr.cs
@@ -99,7 +99,7 @@ public class PgsOcr
 
         using (var bitmap = GetSubtitleBitmap(index))
         using (var image = GetPix(bitmap))
-        using (var page = engine.Process(image))
+        using (var page = engine.Process(image, PageSegMode.SingleBlock))
         {
             result = page.GetText();
             result = result?.Trim();


### PR DESCRIPTION
I noticed that some short lines were detected as "empty page" by tesseract. The fix for this seems to be to use another page segmentation mode. The SingleBlock segmentation mode greatly improves line detection and through that also OCR accuracy in this use case. The documentation for page segmentation modes can be found here:

https://tesseract-ocr.github.io/tessdoc/ImproveQuality.html#page-segmentation-method